### PR TITLE
add code snippet for printing to std::cout

### DIFF
--- a/snippets/cpp.json
+++ b/snippets/cpp.json
@@ -235,5 +235,12 @@
 			"};"
 		],
 		"description": "Code snippet for union"
+	},
+	"cout": {
+		"prefix": "cout",
+		"body": [
+			"std::cout << \"${1:/* message */}\" << \"\\n\";"
+		],
+		"description": "Code snippet for printing to std::cout"
 	}
 }


### PR DESCRIPTION
This is basically taken from atom. The snippet requires <iostream> headers to be set (obv.).