### PR TITLE
Else If and For loop tabs

### DIFF
--- a/snippets/c.json
+++ b/snippets/c.json
@@ -2,9 +2,9 @@
 	"for": {
 		"prefix": "for",
 		"body": [
-			"for (${size_t} ${i} = ${1:0}; ${i} < ${length}; ${i}++)",
+			"for (${size_t} ${i} = ${1:0}; ${i} < ${2:length}; ${i}++)",
 			"{",
-			"	$2",
+			"	$3",
 			"}"
 		],
 		"description": "Code snippet for 'for' loop"
@@ -12,9 +12,9 @@
 	"forr": {
 		"prefix": "forr",
 		"body": [
-			"for (int ${i} = ${length} - 1; ${i} >= 0; ${i}--)",
+			"for (int ${i} = ${1:length} - 1; ${i} >= ${2:0}; ${i}--)",
 			"{",
-			"	$1",
+			"	$3",
 			"}"
 		],
 		"description": "Code snippet for reverse 'for' loop"
@@ -48,6 +48,16 @@
 			"}"
 		],
 		"description": "Code snippet for else statement"
+	},
+	"elseif": {
+		"prefix": "elseif",
+		"body": [
+			"elseif ($1)",
+			"{",
+			"	$2",
+			"}"
+		],
+		"description": "Code snippet for else-if statement"
 	},
 	"enum": {
 		"prefix": "enum",

--- a/snippets/c.json
+++ b/snippets/c.json
@@ -49,10 +49,10 @@
 		],
 		"description": "Code snippet for else statement"
 	},
-	"elseif": {
-		"prefix": "elseif",
+	"else if": {
+		"prefix": "else if",
 		"body": [
-			"elseif ($1)",
+			"else if ($1)",
 			"{",
 			"	$2",
 			"}"

--- a/snippets/cpp.json
+++ b/snippets/cpp.json
@@ -72,7 +72,7 @@
 	"elseif": {
 		"prefix": "elseif",
 		"body": [
-			"elseif ($1)",
+			"else if ($1)",
 			"{",
 			"	$2",
 			"}"

--- a/snippets/cpp.json
+++ b/snippets/cpp.json
@@ -2,9 +2,9 @@
 	"for": {
 		"prefix": "for",
 		"body": [
-			"for (${size_t} ${i} = ${1:0}; ${i} < ${length}; ${i}++)",
+			"for (${size_t} ${i} = ${1:0}; ${i} < ${2:length}; ${i}++)",
 			"{",
-			"	$2",
+			"	$3",
 			"}"
 		],
 		"description": "Code snippet for 'for' loop"
@@ -12,9 +12,9 @@
 	"forr": {
 		"prefix": "forr",
 		"body": [
-			"for (int ${i} = ${length} - 1; ${i} >= 0; ${i}--)",
+			"for (int ${i} = ${1:length} - 1; ${i} >= ${2:0}; ${i}--)",
 			"{",
-			"	$1",
+			"	$3",
 			"}"
 		],
 		"description": "Code snippet for reverse 'for' loop"
@@ -68,6 +68,16 @@
 			"}"
 		],
 		"description": "Code snippet for else statement"
+	},
+	"elseif": {
+		"prefix": "elseif",
+		"body": [
+			"elseif ($1)",
+			"{",
+			"	$2",
+			"}"
+		],
+		"description": "Code snippet for else-if statement"
 	},
 	"enum": {
 		"prefix": "enum",

--- a/snippets/cpp.json
+++ b/snippets/cpp.json
@@ -69,8 +69,8 @@
 		],
 		"description": "Code snippet for else statement"
 	},
-	"elseif": {
-		"prefix": "elseif",
+	"else if": {
+		"prefix": "else if",
 		"body": [
 			"else if ($1)",
 			"{",


### PR DESCRIPTION
I found that when using For loops, the tab stops were in an unusual order. My natural inclination was to set the bounds of the loop, and then edit the body, but the flow was Start bound -> body -> type -> varname -> final bound, which wasn't particularly useful.

I also added an else if snippet for good measure