### PR TITLE
Replace '\n' -> std::endl in 'cout' cpp snippet

### DIFF
--- a/snippets/cpp.json
+++ b/snippets/cpp.json
@@ -236,7 +236,7 @@
 	"cout": {
 		"prefix": "cout",
 		"body": [
-			"std::cout << \"${1:/* message */}\" << '\\n';"
+			"std::cout << \"${1:/* message */}\" << std::endl;"
 		],
 		"description": "Code snippet for printing to std::cout, provided the header is set"
 	},


### PR DESCRIPTION
**Don't inline '\n'.**

Right off the bat, it's incompatible with Windows where the EOL is CRLF (\r\n). Using std::endl avoids these kind of issues and nuisances.

**EDIT**: I did not include it, but I could've bumped the version as well.. However, it does make sense to only do it if the PR gets merged.