### PR TITLE
Add type casting & new & delete snippets, fixed some stuff

### DIFF
--- a/snippets/cpp.json
+++ b/snippets/cpp.json
@@ -2,20 +2,20 @@
 	"for": {
 		"prefix": "for",
 		"body": [
-			"for (${size_t} ${i} = ${1:0}; ${i} < ${2:length}; ${i}++)",
+			"for (${1:size_t} ${2:i} = ${3:0}; ${2:i} < ${4:length}; ++${2:i})",
 			"{",
-			"	$3",
-			"}"
+			"\t${5}",
+			"}$0"
 		],
 		"description": "Code snippet for 'for' loop"
 	},
 	"forr": {
 		"prefix": "forr",
 		"body": [
-			"for (int ${i} = ${1:length} - 1; ${i} >= ${2:0}; ${i}--)",
+			"for (int ${1:i} = ${2:length} - 1; ${1:i} >= ${3:0}; ${1:i}--)",
 			"{",
-			"	$3",
-			"}"
+			"\t$4",
+			"}$0"
 		],
 		"description": "Code snippet for reverse 'for' loop"
 	},
@@ -24,7 +24,7 @@
 		"body": [
 			"do",
 			"{",
-			"	$1",
+			"\t$1",
 			"} while($2);"
 		],
 		"description": "Code snippet for do...while loop"
@@ -34,7 +34,7 @@
 		"body": [
 			"while ($1)",
 			"{",
-			"	$2",
+			"\t$2",
 			"}"
 		],
 		"description": "Code snippet for while loop"
@@ -42,9 +42,9 @@
 	"foreach": {
 		"prefix": "foreach",
 		"body": [
-			"for(auto ${var} : ${collection_to_loop})",
+			"for(${1|auto,auto&,auto const&|} ${2:var} : ${3:collection})",
 			"{",
-			"	$1",
+			"\t$4",
 			"}"
 		],
 		"description": "Code snippet for range-based for loop (c++11) statement"
@@ -54,7 +54,7 @@
 		"body": [
 			"if ($1)",
 			"{",
-			"	$2",
+			"\t$2",
 			"}"
 		],
 		"description": "Code snippet for if statement"
@@ -64,7 +64,7 @@
 		"body": [
 			"else",
 			"{",
-			"	$1",
+			"\t$1",
 			"}"
 		],
 		"description": "Code snippet for else statement"
@@ -74,7 +74,7 @@
 		"body": [
 			"else if ($1)",
 			"{",
-			"	$2",
+			"\t$2",
 			"}"
 		],
 		"description": "Code snippet for else-if statement"
@@ -82,9 +82,9 @@
 	"enum": {
 		"prefix": "enum",
 		"body": [
-			"enum ${MyEnum}",
+			"enum ${1:MyEnum}",
 			"{",
-			"	$1",
+			"\t$2",
 			"};"
 		],
 		"description": "Code snippet for enum"
@@ -92,7 +92,10 @@
 	"enum class": {
 		"prefix": "enum class",
 		"body": [
-			"enum class ${MyClass} { };"
+			"enum class ${1:MyClass}",
+			"{",
+			"\t$2",
+			"};"
 		],
 		"description": "Code snippet for enum class (c++11)"
 	},
@@ -102,15 +105,15 @@
 			"class ${MyClass}",
 			"{",
 			"public:",
-			"	${MyClass}();",
-			"	${MyClass}(${MyClass} &&) = default;",
-			"	${MyClass}(const ${MyClass} &) = default;",
-			"	${MyClass} &operator=(${MyClass} &&) = default;",
-			"	${MyClass} &operator=(const ${MyClass} &) = default;",
-			"	~${MyClass}();",
+			"\t${MyClass}();",
+			"\t${MyClass}(${MyClass} &&) = default;",
+			"\t${MyClass}(const ${MyClass} &) = default;",
+			"\t${MyClass} &operator=(${MyClass} &&) = default;",
+			"\t${MyClass} &operator=(const ${MyClass} &) = default;",
+			"\t~${MyClass}();",
 			"",
 			"private:",
-			"	$1",
+			"\t$1",
 			"};",
 			"",
 			"${MyClass}::${MyClass}()",
@@ -129,15 +132,15 @@
 			"class ${MyClass}",
 			"{",
 			"public:",
-			"	${MyClass}() = default;",
-			"	${MyClass}(${MyClass} &&) = default;",
-			"	${MyClass}(const ${MyClass} &) = default;",
-			"	${MyClass} &operator=(${MyClass} &&) = default;",
-			"	${MyClass} &operator=(const ${MyClass} &) = default;",
-			"	~${MyClass}() = default;",
+			"\t${MyClass}() = default;",
+			"\t${MyClass}(${MyClass} &&) = default;",
+			"\t${MyClass}(const ${MyClass} &) = default;",
+			"\t${MyClass} &operator=(${MyClass} &&) = default;",
+			"\t${MyClass} &operator=(const ${MyClass} &) = default;",
+			"\t~${MyClass}() = default;",
 			"",
 			"private:",
-			"	$1",
+			"\t$1",
 			"};"
 		],
 		"description": "Code snippet for class with inline constructor/destructor"
@@ -147,7 +150,7 @@
 		"body": [
 			"__interface I${Interface}",
 			"{",
-			"	$1",
+			"\t$1",
 			"};"
 		],
 		"description": "Code snippet for interface (Visual C++)"
@@ -157,7 +160,7 @@
 		"body": [
 			"namespace ${MyNamespace}",
 			"{",
-			"	$1",
+			"\t$1",
 			"}"
 		],
 		"description": "Code snippet for namespace"
@@ -194,7 +197,7 @@
 		"body": [
 			"struct ${MyStruct}",
 			"{",
-			"	$1",
+			"\t$1",
 			"};"
 		],
 		"description": "Code snippet for struct"
@@ -205,7 +208,7 @@
 			"switch (${switch_on})",
 			"{",
 			"default:",
-			"	break;$1",
+			"\tbreak;$1",
 			"}"
 		],
 		"description": "Code snippet for switch statement"
@@ -215,11 +218,11 @@
 		"body": [
 			"try",
 			"{",
-			"	",
+			"\t",
 			"}",
-			"catch (const std::exception&)",
+			"catch (std::exception const& e)",
 			"{",
-			"	$1",
+			"\t$1",
 			"}"
 		],
 		"description": "Code snippet for try catch"
@@ -229,7 +232,7 @@
 		"body": [
 			"union ${MyUnion}",
 			"{",
-			"	$1",
+			"\t$1",
 			"};"
 		],
 		"description": "Code snippet for union"
@@ -237,7 +240,7 @@
 	"cout": {
 		"prefix": "cout",
 		"body": [
-			"std::cout << \"${1:/* message */}\" << std::endl;"
+			"std::cout << ${1:/* message */} << '\\n';"
 		],
 		"description": "Code snippet for printing to std::cout, provided the header is set"
 	},
@@ -258,9 +261,9 @@
 	"#def": {
 		"prefix": "#def",
 		"body": [
-			"#define \"$1\" \"$2\" "
-			],
-		"description": "Code snippet for #define \" \""
+			"#define $1 $2"
+		],
+		"description": "Code snippet for #define"
 	},
 	"main": {
 		"prefix": "main",
@@ -271,32 +274,39 @@
 		],
 		"description": "Code snippet for main function"
 	},
-
-	"static_cast":
-	{
+	"static_cast": {
 		"prefix": "static_cast",
 		"body": "static_cast<${1:Type}>(${2:expression})$0",
 		"description": "Code snippet for static_cast"
 	},
-
-	"dynamic_cast":
-	{
+	"dynamic_cast": {
 		"prefix": "dynamic_cast",
 		"body": "dynamic_cast<${1:Type}>(${2:expression})$0",
 		"description": "Code snippet for dynamic_cast"
 	},
-
-	"reinterpret_cast":
-	{
+	"reinterpret_cast": {
 		"prefix": "reinterpret_cast",
 		"body": "reinterpret_cast<${1:Type}>(${2:expression})$0",
 		"description": "Code snippet for reinterpret_cast"
 	},
-
-	"const_cast":
-	{
+	"const_cast": {
 		"prefix": "const_cast",
 		"body": "const_cast<${1:Type}>(${2:expression})$0",
 		"description": "Code snippet for const_cast"
+	},
+	"new": {
+		"prefix": "new",
+		"body": "new ${1:Type}${2:[${3:count}]}${4:(${5:initializer})};$0",
+		"description": "Code snippet for new operator"
+	},
+	"placement-new": {
+		"prefix": "placement new",
+		"body": "new(${1:place}) ${2:Type}${3:(${4:initializer})};$0",
+		"description": "Code snippet for placement new operator"
+	},
+	"delete": {
+		"prefix": "delete",
+		"body": "delete${1:[]} ${2:expression};$0",
+		"description": "Code snippet for delete operator"
 	}
 }

--- a/snippets/cpp.json
+++ b/snippets/cpp.json
@@ -270,5 +270,33 @@
 			"}"
 		],
 		"description": "Code snippet for main function"
+	},
+
+	"static_cast":
+	{
+		"prefix": "static_cast",
+		"body": "static_cast<${1:Type}>(${2:expression})$0",
+		"description": "Code snippet for static_cast"
+	},
+
+	"dynamic_cast":
+	{
+		"prefix": "dynamic_cast",
+		"body": "dynamic_cast<${1:Type}>(${2:expression})$0",
+		"description": "Code snippet for dynamic_cast"
+	},
+
+	"reinterpret_cast":
+	{
+		"prefix": "reinterpret_cast",
+		"body": "reinterpret_cast<${1:Type}>(${2:expression})$0",
+		"description": "Code snippet for reinterpret_cast"
+	},
+
+	"const_cast":
+	{
+		"prefix": "const_cast",
+		"body": "const_cast<${1:Type}>(${2:expression})$0",
+		"description": "Code snippet for const_cast"
 	}
 }

--- a/snippets/cpp.json
+++ b/snippets/cpp.json
@@ -268,8 +268,9 @@
 	"main": {
 		"prefix": "main",
 		"body": [
-			"int main(int argc, const char** argv) {",
-			"    return 0;",
+			"int main(int argc, const char** argv)",
+			"{",
+			"$0",
 			"}"
 		],
 		"description": "Code snippet for main function"


### PR DESCRIPTION
Please note that most of the previous snippets already existed in vscode-cpp-tools. If user install both extensions, it will create new entries with duplicate names, which could be quite confusing. Consider delete them 